### PR TITLE
Mobile styling adjustments

### DIFF
--- a/css/mobile-menu.css
+++ b/css/mobile-menu.css
@@ -217,7 +217,7 @@ ul.rosterMenu a:hover {
         padding: 0 !important;
         margin: 0 !important;
         background: #333 !important;
-        position: absolute !important;
+        position: fixed !important;
         top: 51px !important; 
         width: calc(100% - 2px) !important;
         z-index: 1000 !important;
@@ -327,6 +327,105 @@ ul.rosterMenu a:hover {
         border: none !important;
         white-space: normal !important;
         word-wrap: break-word !important;
+    }
+    /* matches tables */
+    .matchesTable tr:nth-child(2),
+    .matchesTable tr:nth-child(4),
+    .matchesTable tr:nth-child(3),
+    .matchesTable tr:nth-last-child(2) {
+        display: none !important;
+    }
+
+    .matchesTable tr {
+        display: block;
+        border: 1px black solid;
+        position: relative;
+    }
+
+    .matchesTable tr td {
+        display: block;
+        margin: 2px 0px;
+    }
+    .matchesTable tr:not(:first-child) td:nth-child(-n+3) {
+        display: inline-flex;
+        width: 32.5%;
+    }
+    .matchesTable tr:not(:first-child) td:nth-child(2) a {
+        text-align: center;
+        width: 100%;
+    }
+    .matchesTable tr:not(:first-child) td:nth-child(3) a {
+        text-align: right;
+        width: 100%;
+    }
+    .matchesTable tr td:nth-child(4) {
+        width: 100%;
+    }
+
+    .matchesTable tr td:nth-child(5) {
+        float: left;
+    }
+    .matchesTable tr td:nth-child(6)  {
+        float: right;
+    }
+    .matchesTable tr td:nth-child(5) i,
+    .matchesTable tr td:nth-child(6) i {
+        visibility: hidden;
+        display: block;
+        text-align: center;
+        padding: 10px 0px 0px 0px;
+    }
+    .matchesTable tr td:nth-child(6) i {
+        text-align: center;
+    }
+    .matchesTable tr td:nth-child(5) i a,
+    .matchesTable tr td:nth-child(6) i a {
+        visibility: visible;
+    }
+
+    .matchesTable tr td:nth-last-child(1) {
+        clear: both;
+        padding: 5px;
+        text-align: center;
+    }
+    .matchesTable tr:nth-last-child(1) {
+        display: block;
+        height: 35px;
+    }
+    .matchesTable tr:last-child td:nth-child(1) {
+        display: block;
+        width: 95%;
+    }
+    .tourMatches a {
+        font-size: 14px;
+        color: black;
+    }
+
+    .tourMatches td > a {
+        display: inline-flex;
+    }
+    .tourMatches tr  td  i a {
+        visibility: visible;
+    }
+
+    .tourMatches tr  td  i {
+        visibility: hidden;
+    }
+
+    td.matchManagement {
+        width: 26%;
+    }
+
+    td.match.divider {
+        display: none;
+    }
+
+    .tourMatches {
+        color: black;
+    }
+    /* team about form */
+    .teamAbout tr:nth-child(2) td:nth-child(3) form {
+        width: 450px;
     }
 }
 

--- a/lib/class_htmlout.php
+++ b/lib/class_htmlout.php
@@ -142,7 +142,8 @@ class HTMLOUT
 			$fields,
 			array('+round','+date_created'),
 			(isset($_GET["sort$opts[GET_SS]"])) ? array((($_GET["dir$opts[GET_SS]"] == 'a') ? '+' : '-') . $_GET["sort$opts[GET_SS]"]) : array(),
-			$extra
+			$extra,
+			'matchesTable'
 		);
 	}
 	
@@ -1261,7 +1262,7 @@ class HTMLOUT
 	}
 	
 	// Prints an advanced sort table.
-	public static function sort_table($title, $lnk, array $objs, array $fields, array $std_sort, $sort = array(), $extra = array())	{
+	public static function sort_table($title, $lnk, array $objs, array $fields, array $std_sort, $sort = array(), $extra = array(), $tableClassName = 'tableResponsive')	{
 		/*
 			extra fields:
 				tableWidth  => CSS style width value
@@ -1309,7 +1310,7 @@ class HTMLOUT
 		$CP = count($fields);
 		?>
 		<!-- Following HTML from ./lib/class_htmlout.php sort_table-->
-		<div class='tableResponsive'>
+		<div class="<?php echo $tableClassName;?>">
 		<table class="common" <?php echo (array_key_exists('tableWidth', $extra)) ? "style='width: $extra[tableWidth];'" : '';?>>
 			<tr class="commonhead">
 				<td colspan="<?php echo $CP;?>"><b>

--- a/lib/class_match_htmlout.php
+++ b/lib/class_match_htmlout.php
@@ -64,7 +64,7 @@ class Match_HTMLOUT extends Match
 		$_url = "?section=matches&amp;type=tourmatches&amp;trid=$trid&amp;";
 		title(get_alt_col('tours', 'tour_id', $trid, 'name'));
 		echo '<!-- Following HTML from ./lib/class_match_htmlout.php tourMatches -->';
-		echo "<div class='tableResponsive'>\n";
+		echo "<div class='tourMatchesSummary'>\n";
 		echo '<center><table>';
 		echo '<tr><td>';
 		echo 'Page: '.implode(', ', array_map(create_function('$nr', 'global $page; return ($nr == $page) ? $nr : "<a href=\''.$_url.'page=$nr\'>$nr</a>";'), range(1,$pages)));
@@ -80,7 +80,7 @@ class Match_HTMLOUT extends Match
 			FROM matches, teams AS t1, teams AS t2 WHERE f_tour_id = $trid AND team1_id = t1.team_id AND team2_id = t2.team_id
 			ORDER BY round $ROUND_SORT_DIR, date_played DESC, date_created ASC LIMIT ".(($page-1)*self::T_HTML_MATCHES_PER_PAGE).', '.(($page)*self::T_HTML_MATCHES_PER_PAGE);
 		$result = mysql_query($query);
-		echo "<div class='tableResponsive'>\n";
+		echo "<div class='tourMatches'>\n";
 		echo "<table class='tours'>\n";
 		while ($m = mysql_fetch_object($result)) {
 			if ($m->round != $rnd) {
@@ -101,24 +101,24 @@ class Match_HTMLOUT extends Match
 				<td><?php echo !empty($m->date_played) ? textdate($m->date_played, true) : ''; ?></td>
 				<td class="match" style="text-align: right;">
 					<?php 
-					echo "<a href='".urlcompile(T_URL_PROFILE,T_OBJ_TEAM,$m->t1_id,false,false)."'>$m->t1_name</a>&nbsp;<i>(<a href='".urlcompile(T_URL_PROFILE,T_OBJ_COACH,$m->c1_id,false,false)."'>$m->c1_name</a>)</i>";
+					echo "<a href='".urlcompile(T_URL_PROFILE,T_OBJ_TEAM,$m->t1_id,false,false)."'>$m->t1_name</a><i>(<a href='".urlcompile(T_URL_PROFILE,T_OBJ_COACH,$m->c1_id,false,false)."'>$m->c1_name</a>)</i>";
 					?>
 				</td>
-				<td class="match" style="text-align: center;"><?php echo !empty($m->date_played) ? $m->team1_score : '';?></td>
-				<td class="match" style="text-align: center;">-</td>
-				<td class="match" style="text-align: center;"><?php echo !empty($m->date_played) ? $m->team2_score : '';?></td>
+				<td class="match divider" style="text-align: center;"><?php echo !empty($m->date_played) ? $m->team1_score : '';?></td>
+				<td class="match divider" style="text-align: center;">-</td>
+				<td class="match divider" style="text-align: center;"><?php echo !empty($m->date_played) ? $m->team2_score : '';?></td>
 				<td class="match" style="text-align: left;">
 					<?php 
-					echo "<a href='".urlcompile(T_URL_PROFILE,T_OBJ_TEAM,$m->t2_id,false,false)."'>$m->t2_name</a>&nbsp;<i>(<a href='".urlcompile(T_URL_PROFILE,T_OBJ_COACH,$m->c2_id,false,false)."'>$m->c2_name</a>)</i>";
+					echo "<a href='".urlcompile(T_URL_PROFILE,T_OBJ_TEAM,$m->t2_id,false,false)."'>$m->t2_name</a><i>(<a href='".urlcompile(T_URL_PROFILE,T_OBJ_COACH,$m->c2_id,false,false)."'>$m->c2_name</a>)</i>";
 					?>
 				</td>
 				<?php
 				// Does the user have edit or view rights?
 				$matchURL = "index.php?section=matches&amp;type=tourmatches&amp;trid=$trid&amp;mid=$m->match_id";
 				?>
-				<td>
+				<td class="matchManagement">
 				<?php
-				echo "&nbsp;<a href='index.php?section=matches&amp;type=report&amp;mid=$m->match_id'>".$lng->getTrn('common/view')."</a>&nbsp;\n";
+				echo "<a href='index.php?section=matches&amp;type=report&amp;mid=$m->match_id'>".$lng->getTrn('common/view')."</a>\n";
 				if ($IS_LOCAL_ADMIN) {
 					?>
 					<script language="JavaScript" type="text/javascript">
@@ -130,9 +130,9 @@ class Match_HTMLOUT extends Match
 						}
 					</script>
 					<?php
-					echo "<a onclick=\"return match_reset();\" href='$matchURL&amp;action=reset'>".$lng->getTrn('common/reset')."</a>&nbsp;\n";
-					echo "<a onclick=\"return match_delete();\" href='$matchURL&amp;action=delete' style='color:".(!empty($m->date_played) ? 'Red' : 'Blue').";'>".$lng->getTrn('common/delete')."</a>&nbsp;\n";
-					echo "<a href='$matchURL&amp;action=".(($m->locked) ? 'unlock' : 'lock')."'>" . ($m->locked ? $lng->getTrn('common/unlock') : $lng->getTrn('common/lock')) . "</a>&nbsp;\n";
+					echo "<a onclick=\"return match_reset();\" href='$matchURL&amp;action=reset'>".$lng->getTrn('common/reset')."</a>\n";
+					echo "<a onclick=\"return match_delete();\" href='$matchURL&amp;action=delete' style='color:".(!empty($m->date_played) ? 'Red' : 'Blue').";'>".$lng->getTrn('common/delete')."</a>\n";
+					echo "<a href='$matchURL&amp;action=".(($m->locked) ? 'unlock' : 'lock')."'>" . ($m->locked ? $lng->getTrn('common/unlock') : $lng->getTrn('common/lock')) . "</a>\n";
 				}
 				?>
 				</td>
@@ -194,7 +194,7 @@ class Match_HTMLOUT extends Match
 
 		// Print fixture list.
 		foreach ($flist as $lid => $divs) {
-			# Container
+			# Container TODO
 			echo "<div id='lid_${lid}_cont' class='leaguesNCont' style='".((in_array("lid_${lid}", $flist_JShides)) ? "display:none;" : '')."'>";
 			# Title
 			echo "<div class='leagues'><b><a href='javascript:void(0);' onClick=\"slideToggleFast('lid_$lid');\">[+/-]</a>&nbsp;".$flist[$lid]['desc']['lname']."</b></div>\n";

--- a/lib/class_team_htmlout.php
+++ b/lib/class_team_htmlout.php
@@ -2711,7 +2711,7 @@ class Team_HTMLOUT extends Team
 		?>
 		<!-- Following HTML is from class_team_htmlout.php _about -->
 		<div class='tableResponsive'>
-		<table class='common'>
+		<table class='common teamAbout'>
 
 			<tr class='commonhead'>
 				<td><b><?php echo $lng->getTrn('profile/team/logo');?></b></td>


### PR DESCRIPTION
- Adjust match tables
- Fix mobile menu to be 'fixed'
- Set width of About on team page to be 450px

<img width="1442" height="3202" alt="leagueHistory-Tournaments-Matches" src="https://github.com/user-attachments/assets/2a2378ae-a1d4-4b38-bfde-2922864f7be9" />
<img width="1442" height="3202" alt="upcomingMatches" src="https://github.com/user-attachments/assets/9639e0b7-feb4-48a4-a836-769ac56a46db" />
<img width="1442" height="3202" alt="teamAbout" src="https://github.com/user-attachments/assets/ca8616f4-093e-4cb9-91f2-5093601c9d76" />
